### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": ">= 16.8.0 < 2",
-    "react-dom": ">= 16.8.0 < 2"
+    "react": ">= 16.8.0 < 17",
+    "react-dom": ">= 16.8.0 < 17"
   },
   "devDependencies": {
     "@types/react": "^16.3.13",


### PR DESCRIPTION
The ranges before were invalid - <2 but >16.8.0 isn't ever going to exist.

The new value matches what I'm guessing was the previous intent: 16.8.0 up to the next major version.

I've tested on https://semver.npmjs.com/

Note: React 17 might also be compatible, I haven't bothered checking. If it is you could update the range to <18