### PR TITLE
Ability to pass root and placeholder elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,59 @@ export const MyItemList = (items) => (
 - `defaultHeight?: number` __Default: 300__ - An estimate of the element's height.
 - `visibleOffset?: number` __Default: 1000__ - How far outside the viewport (or `root` element) in pixels should elements be considered visible?
 - `root?: HTMLElement` __Default: null__ - [Root element](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#intersection_observer_concepts_and_usage) passed to `IntersectionObserver`.
+- `rootElement?: HTMLElement` __Default: "div"__ - This is the HTML element that will wrap around the children and placeholder. This root element is always present.
+- `placeholderElement?: HTMLElement` __Default: "div"__ - This is the HTML element that will be used for the placeholder. This placeholder element is contained in the root element.
 - `children: React.ReactNode` - The component(s)/element(s) for which to defer rendering.
+
+## Example usage
+When using HTML tables, you can change the default rootElement from "div" to "tbody". For example:
+```javascript
+import React from 'react'
+import RenderIfVisible from 'react-render-if-visible'
+import MyListItem from './list-item' 
+
+const ESTIMATED_ITEM_HEIGHT = 200
+
+export const MyItemList = (items) => (
+  <table className="my-list">
+    <colgroup>
+      <col><col>
+    </colgroup>
+    {items.map(item => (
+      <RenderIfVisible defaultHeight={ESTIMATED_ITEM_HEIGHT} rootElement={"tbody"} placeholderElement={"tr"}>
+        <MyListItem item={item} />
+      </RenderIfVisible>
+    ))}
+  </table>
+)
+```
+The example above, builds a valid HTML table like the one shown below:
+```
+  <table class="my-list">
+    <colgroup>
+      <col><col>
+    </colgroup>
+    <tbody class="renderIfVisible">
+      <tr><td>col1</td><td>col2</td></tr>
+    </tbody>
+    <tbody class="renderIfVisible">
+      <tr><td>col1</td><td>col2</td></tr>
+    </tbody>
+    <tbody class="renderIfVisible">
+      <tr><td>col1</td><td>col2</td></tr>
+    </tbody>
+    <tbody class="renderIfVisible">
+      <tr><td>col1</td><td>col2</td></tr>
+    </tbody>
+    ... (offscreen)
+    <tbody class="renderIfVisible">
+      <tr class="renderIfVisible-placeholder" style="height:200px"></tr>
+    </tbody>
+    <tbody class="renderIfVisible">
+      <tr class="renderIfVisible-placeholder" style="height:200px"></tr>
+    </tbody>
+    <tbody class="renderIfVisible">
+      <tr class="renderIfVisible-placeholder" style="height:200px"></tr>
+    </tbody>
+  </table>
+```

--- a/src/render-if-visible.tsx
+++ b/src/render-if-visible.tsx
@@ -59,7 +59,8 @@ const RenderIfVisible = ({
       placeholderHeight.current = intersectionRef.current.offsetHeight
     }
   }, [isVisible, intersectionRef])
-
+  const placeholderStyle = { height: placeholderHeight.current };
+  
   return React.createElement(
         rootElement,
         {

--- a/src/render-if-visible.tsx
+++ b/src/render-if-visible.tsx
@@ -9,7 +9,9 @@ type Props = {
   visibleOffset?: number
   root?: HTMLElement | null
   rootElement?: HTMLElement
+  rootElementClass?: string
   placeholderElement?: HTMLElement
+  placeholderElementClass?: string
   children: React.ReactNode
 }
 
@@ -18,7 +20,9 @@ const RenderIfVisible = ({
   visibleOffset = 1000,
   root = null,
   rootElement = "div",
+  rootElementClass = "",
   placeholderElement = "div",
+  placeholderElementClass = "",
   children
 }: Props) => {
   const [isVisible, setIsVisible] = useState<boolean>(isServer)
@@ -60,6 +64,8 @@ const RenderIfVisible = ({
     }
   }, [isVisible, intersectionRef])
   const placeholderStyle = { height: placeholderHeight.current };
+  const rootClasses = useMemo(() => `renderIfVisible ${rootElementClass}`, [rootElementClass]);
+  const placeHolderClasses = useMemo(() => `renderIfVisible-placeholder ${placeholderElementClass}`, [placeholderElementClass]);
   
   return React.createElement(
         rootElement,
@@ -68,10 +74,10 @@ const RenderIfVisible = ({
                 ? (<>{children}</>)
                 : React.createElement(
                     placeholderElement,
-                    { className: "renderIfVisible-placeholder", style: placeholderStyle }
+                    { className: placeholderClasses, style: placeholderStyle }
                 ),
             ref: intersectionRef,
-            className: "renderIfVisible",
+            className: rootClasses,
         },
     );
 }

--- a/src/render-if-visible.tsx
+++ b/src/render-if-visible.tsx
@@ -8,6 +8,8 @@ type Props = {
   /** How far outside the viewport in pixels should elements be considered visible?  */
   visibleOffset?: number
   root?: HTMLElement | null
+  rootElement?: HTMLElement
+  placeholderElement?: HTMLElement
   children: React.ReactNode
 }
 
@@ -15,6 +17,8 @@ const RenderIfVisible = ({
   defaultHeight = 300,
   visibleOffset = 1000,
   root = null,
+  rootElement = "div",
+  placeholderElement = "div",
   children
 }: Props) => {
   const [isVisible, setIsVisible] = useState<boolean>(isServer)
@@ -56,15 +60,19 @@ const RenderIfVisible = ({
     }
   }, [isVisible, intersectionRef])
 
-  return (
-    <div ref={intersectionRef}>
-      {isVisible ? (
-        <>{children}</>
-      ) : (
-        <div style={{ height: placeholderHeight.current }} />
-      )}
-    </div>
-  )
+  return React.createElement(
+        rootElement,
+        {
+            children: isVisible
+                ? (<>{children}</>)
+                : React.createElement(
+                    placeholderElement,
+                    { className: "renderIfVisible-placeholder", style: placeholderStyle }
+                ),
+            ref: intersectionRef,
+            className: "renderIfVisible",
+        },
+    );
 }
 
 export default RenderIfVisible


### PR DESCRIPTION
This is a way to allow users to pass a rootElement of any html element like tr or span. By default it uses div. 
Also allows you to provide a placeholderElement of any html element like tr or span. By default it uses div.

This allows people that are trying to use this with tables to provide the type of html element they want the root and/or placeholder elements to be so it complies with valid html.