### PR TITLE
Add rootElementStyle

### DIFF
--- a/src/render-if-visible.tsx
+++ b/src/render-if-visible.tsx
@@ -17,6 +17,7 @@ type Props = {
   /** E.g. 'span', 'tbody'. Default = 'div' */
   rootElement?: string
   rootElementClass?: string
+  rootElementStyle?: React.CSSProperties;
   /** E.g. 'span', 'tr'. Default = 'div' */
   placeholderElement?: string
   placeholderElementClass?: string
@@ -31,6 +32,7 @@ const RenderIfVisible = ({
   root = null,
   rootElement = 'div',
   rootElementClass = '',
+  rootElementStyle = {},
   placeholderElement = 'div',
   placeholderElementClass = '',
   children,
@@ -101,6 +103,7 @@ const RenderIfVisible = ({
     ),
     ref: intersectionRef,
     className: rootClasses,
+    style: rootElementStyle,
   })
 }
 


### PR DESCRIPTION
Useful when there are computed styles that don't slot into the rootElementClass