### PR TITLE
Issue #12 suggestion - add root and visibleOffset to useEffect deps

### DIFF
--- a/src/render-if-visible.tsx
+++ b/src/render-if-visible.tsx
@@ -72,7 +72,7 @@ const RenderIfVisible = ({
       }
     }
     return () => {}
-  }, [])
+  }, [root, visibleOffset])
 
   useEffect(() => {
     if (isVisible) {


### PR DESCRIPTION
Issue: https://github.com/NightCafeStudio/react-render-if-visible/issues/12

This is a great library! I think this PR would be helpful for one of our use cases for two main reasons, and also adding these props to the dependencies array follows the rule of hooks:

1. Currently root must be defined on the first render or it will always be `null` - this allows root to be defined on subsequent renders. Using an element that is not available in the DOM on the first render is something we are currently doing. 
2. If root is null, then `rootMargin` in the intersection observer library [is not applied](https://w3c.github.io/IntersectionObserver/#intersectionobserver-implicit-root)